### PR TITLE
Stupid simple

### DIFF
--- a/docs/introduccion.md
+++ b/docs/introduccion.md
@@ -143,7 +143,7 @@ El descubrimiento de un orden no es tarea fácil. . . . sin embargo, una vez que
 
 - Kelly Johnson
   - Keep it simple, stupid! - Mantenlo sencillo, estúpido!
-  - Keep it simple stupid! - Mantenlo estúpidamente sencillo
+  - Keep it stupid simple! - Mantenlo estúpidamente sencillo
   - Keep it small & simple - Mantenlo pequeño y sencillo!
   - Keep it short and simple - Mantenlo pequeño y simple!
 - Lo contrario a:


### PR DESCRIPTION
Corrección ortográfica de “keep it simple stupid” a “keep it stupid simple”